### PR TITLE
Fixes two tiny typos.

### DIFF
--- a/export-PS1.gist
+++ b/export-PS1.gist
@@ -3,10 +3,10 @@ export PS1="\[\033[36m\]\u\[\033[32m\]\w\[\033[33m\]\$(git_branch)\$(parse_git_d
 
 # Find dirty state
 function parse_git_dirty {
-  [[ -n "$(git status -s2> /dev/null)" ]] && echo "*"
+  [[ -n "$(git status -s 2> /dev/null)" ]] && echo "*"
 }
 
 # Get branch name
 git_branch() {
-  git branch 2> /dev/null | sed -e '/^[^*]/d' -d 's/* \(.*\)/ (\1)/'
+  git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
 }


### PR DESCRIPTION
Found two tiny typos:
* `sed -d` should be `sed -e`
* space missing before `2>`

Thanks for this gist :)